### PR TITLE
Add loose option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,4 @@ jobs:
         uses: ./
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          loose: '0'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ![Test Milestone Binder](https://github.com/Code-Hex/auto-milestone-binder/workflows/Test%20Milestone%20Binder/badge.svg)
 
 An action for binding milestone to some PR or some issues.
+When a pull request is opened without a milestone, this action finds a milestone which has smallest version string in the title
+and set the milestone to the pull request.
 
 You can see the example: https://github.com/Code-Hex/auto-milestone-binder/issues/7
 
@@ -24,6 +26,7 @@ jobs:
     - uses: Code-Hex/auto-milestone-binder@v1.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        loose: '0'
 ```
 
 # License

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   github-token:
     description: 'Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
     required: true
+  loose:
+    description: 'Find any semver string in the title of milestone. Default is false.'
+    required: false
+    default: '0'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,17 +27,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.pickSmallestVersion = exports.existsMilestone = void 0;
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
 const compare_versions_1 = __importDefault(require("compare-versions"));
@@ -32,13 +45,24 @@ exports.existsMilestone = (payload) => {
     }
     return false;
 };
-exports.pickSmallestVersion = (milestones) => {
-    const sortedMilestones = milestones.data
-        .filter((v) => compare_versions_1.default.validate(v.title))
+exports.pickSmallestVersion = (milestones, loose) => {
+    const normalizedTitle = loose ? (milestone) => {
+        const m = milestone.title.match(/\bv\d+\.\d+\.\d+/);
+        if (m !== null) {
+            return m[0];
+        }
+        else {
+            return milestone.title;
+        }
+    } : (milestone) => {
+        return milestone.title;
+    };
+    return milestones.data
+        .filter((v) => compare_versions_1.default.validate(normalizedTitle(v)))
         .sort((a, b) => {
-        return compare_versions_1.default(a.title, b.title);
-    });
-    return sortedMilestones[0];
+        return compare_versions_1.default(normalizedTitle(a), normalizedTitle(b));
+    })
+        .shift();
 };
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -65,11 +89,16 @@ function run() {
             console.log('There are no milestones, skipping.');
             return;
         }
-        const smallestVersion = exports.pickSmallestVersion(milestones);
+        const loose = core.getInput('loose');
+        const smallestVersion = exports.pickSmallestVersion(milestones, !!Number(loose));
+        if (smallestVersion === undefined) {
+            console.log("failed to find valid milestone.");
+            return;
+        }
         yield client.issues.update(Object.assign(Object.assign({}, repo), { issue_number: issue.number, milestone: smallestVersion.number }));
         core.setOutput('milestone', smallestVersion);
     });
 }
 run().catch(err => {
-    core.setFailed(err.message);
+    core.setFailed(err);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-milestone-binder",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An action for binding milestone to some PR or some issues",
   "main": "lib/main.js",
   "author": "Code-Hex",

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -19,7 +19,7 @@ const makeMilestone = (title: string, number: number): {title:string,number:numb
   }
 }
 
-describe('pickSmallestVersion', () => {
+describe('pickSmallestVersion strict', () => {
   test.each([
     [1, {
       data: [
@@ -38,7 +38,31 @@ describe('pickSmallestVersion', () => {
       ]
     }],
   ])("expected '%p', argument: %o", (want, arg) => {
-    const got = pickSmallestVersion(arg)
-    expect(got.number).toBe(want)
+    const got = pickSmallestVersion(arg, false)
+    if (got === undefined) {
+      fail('it should not be undefined');
+    } else {
+      expect(got.number).toBe(want)
+    }
+  })
+})
+
+describe('pickSmallestVersion loose', () => {
+  test.each([
+    [2, {
+      data: [
+        makeMilestone('Any', 1),
+        makeMilestone('v1.0.0(alpine)', 2),
+        makeMilestone('v1.1.0(bigbird)', 3),
+        makeMilestone('v1.2.0(coconut)', 4),
+      ]
+    }],
+  ])("expected '%p', argument: %o", (want, arg) => {
+    const got = pickSmallestVersion(arg, true)
+    if (got === undefined) {
+      fail('it should not be undefined');
+    } else {
+      expect(got.number).toBe(want)
+    }
   })
 })


### PR DESCRIPTION
I'm so sorry for creating many empty pull requests on this repository 🙇
Finally this pull request is valid one and this one adds an option which allows the users to use the milestone which has the words other than semver string.

The title of milestones in our repository formatted like `v.1.1.0 (codename)` and this `loose` option make this script work with such milestone titles.